### PR TITLE
Remove padding from flex container in layout so that elements take up…

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,7 @@
  *= require_self
  */
 
+.products-grid::after {
+  content: "";
+  flex: auto;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-28 flex">
       
       <%= yield %>
     </main>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,30 +1,29 @@
-<div class="flex flex-wrap justify-center space-x-2 ">
-<% @products.each do |product| %>
-  <div>
-    <div>
-      <%= image_tag(product.image, class: "product-image mb-2") %>
-    </div>
-
-    <div class="product-details mx-3">
-      <div class="flex justify-between">
-        <div>
-          <%= product.name %>
-        </div>
-        <div>
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-          </svg>
-        </div>
-      </div>
-
+<div class="products-grid flex flex-wrap justify-center space-x-2 ">
+  <% @products.each do |product| %>
+    <div class="flex-none mb-5">
       <div>
-        $<%= product.price %>
+        <%= image_tag(product.image, class: "product-image mb-2") %>
       </div>
-      <div class="mt-3 text-gray-400 text-sm">
-        <%= (1..10).to_a.sample %> colors
+
+      <div class="product-details mx-3">
+        <div class="flex justify-between">
+          <div>
+            <%= product.name %>
+          </div>
+          <div>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+          </div>
+        </div>
+
+        <div>
+          $<%= product.price %>
+        </div>
+        <div class="mt-3 text-gray-400 text-sm">
+          <%= (1..10).to_a.sample %> colors
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
 </div>
-


### PR DESCRIPTION
# Summary
Fixes basic layout issues on the products index page. Previously, the layout was wrapping on large browser screens when there were only two products being displayed. This change allows three products to fit on the page.

# Trello card
https://trello.com/c/KE249Tp1