### PR TITLE
Display appropriate navbar

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,16 +1,3 @@
-<div class="flex justify-between">
-  <div class="underline text-xs">
-    <%= link_to "Back to Shopping", root_path %>
-  </div>
-  <div>
-    <%= link_to image_tag("https://www.aritzia.com/on/demandware.static/Sites-Aritzia_US-Site/-/default/dw9248a3f4/images/aritzia_skin/aritzia_logo.svg", width: 106, height: 21), root_path%>
-  </div>
-  <div class="underline text-xs">
-    Need Help?
-  </div>
-</div>
-
-
 <div class="flex">
   <div class="w-1/3"></div>
   <div class="w-1/3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,15 +1,3 @@
-<div class="flex justify-between">
-  <div class="underline text-xs">
-    <%= link_to "Back to Shopping", root_path %>
-  </div>
-  <div>
-    <%= link_to image_tag("https://www.aritzia.com/on/demandware.static/Sites-Aritzia_US-Site/-/default/dw9248a3f4/images/aritzia_skin/aritzia_logo.svg", width: 106, height: 21), root_path%>
-  </div>
-  <div class="underline text-xs">
-    Need Help?
-  </div>
-</div>
-
 <div class="flex justify-center mt-12 ml-12">
   SIGN IN OR CREATE AN ACCOUNT TO UNLOCK:
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,22 @@
 
   <body class="bg-aritzia">
     <main class="mx-10 mt-5">
-    <% if params[:controller]== 'products' %>
-      <%= render "layouts/navbar" %> 
-    <% end %>
+      <% if params[:controller]== 'sessions' || params[:controller] == 'registrations' %>
+        <div class="flex justify-between">
+          <div class="underline text-xs">
+            <%= link_to "Back to Shopping", root_path %>
+          </div>
+          <div>
+            <%= link_to image_tag("https://www.aritzia.com/on/demandware.static/Sites-Aritzia_US-Site/-/default/dw9248a3f4/images/aritzia_skin/aritzia_logo.svg", width: 106, height: 21), root_path%>
+          </div>
+          <div class="underline text-xs">
+            Need Help?
+          </div>
+        </div>
+      <% else %>
+        <%= render "layouts/navbar" %> 
+      <% end %>
+
       <%= yield %>
 
       <p class="notice"><%= notice %></p>


### PR DESCRIPTION
# Summary

This PR makes sure there is a navbar on every page. Previously, if the page was not a products page or a Devise page, no navbar would appear.


# Trello Card 

https://trello.com/c/TC19DWIL/21-make-sure-a-navbar-appears-on-every-page

 