### PR TITLE
add brand to product display on index

### DIFF
--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -5,25 +5,29 @@
         <%= link_to image_tag(product.image, class: "product-image mb-2", width: 390, height: 550), product_path(product) %>
       </div>
 
-      <div class="product-details mx-3">
+      <div class="product-details mx-3 text-sm">
         <div class="flex justify-between">
           <div>
-            <%= link_to product.name, product_path(product) %>
+            <%= link_to product.brand, product_path(product) %>
           </div>
           <form class="favorite-ribbon" method="post" action="/favorites?product_id=<%= product.id %>">
             <button type="submit">
               <% if current_user && product.favorited_by?(current_user) %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
-              </svg>
-            <% else %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-              </svg>
-            <% end %>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
+                </svg>
+              <% else %>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                </svg>
+              <% end %>
             </button>
           </form>
         </div>
+
+          <div>
+            <%= link_to product.name, product_path(product) %>
+          </div>
 
         <div>
           $<%= product.price %>


### PR DESCRIPTION
# Summary

This PR adds the brand name to the product display on the product index page. The size of the bookmark icon was also made smaller to prevent blank space under the flex box containing the bookmark icon and the brand name. The text size of the product details was changed to be small using the tailwind class. 

# Trello Card 

https://trello.com/c/PoOzBEXV/26-include-brand-on-product-page

 # Screenshot

<img width="1043" alt="Screen Shot 2022-06-05 at 8 05 34 PM" src="https://user-images.githubusercontent.com/92960084/172076161-1e9635eb-6e52-49ca-bb43-39bd81378dcc.png">

#Followups 

I added a new trello card to fix the margin between the body of the page and the footer. This especially shows on the sign in/ sign up pages. 


